### PR TITLE
Image saving album name fix

### DIFF
--- a/lib/screens/gallery/image_browser.dart
+++ b/lib/screens/gallery/image_browser.dart
@@ -35,7 +35,7 @@ class _ImageBrowserPageState extends State<ImageBrowserPage> {
                         .large!["url"]!}"));
                 ImageSave.saveImage(
                     image.bodyBytes,
-                    "${widget.album.images![index].filename!}");
+                    "${widget.album.images![index].filename!}", albumName: "F-sektionen");
                 ScaffoldMessenger.of(context).showSnackBar(
                     new SnackBar(content: Text(t.galleryImageDownloaded),));
               } on Exception catch (_) {


### PR DESCRIPTION
Saves images in an album named "F-sektionen" instead of "null"