### PR TITLE
It used the wrong field to determine whether notification has been seen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -96,7 +96,7 @@
     "otherLogOutConfirm": "Are you sure you want to log out?",
     "otherCancel": "Cancel",
 
-    "notificationsSent": "Sent",
+    "notificationsSent": "Sent ",
     "notificationsNone": "No notifications available",
 
     "contactContact": "Contact",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -96,7 +96,7 @@
     "otherLogOutConfirm": "Är du säker på att du vill logga ut?",
     "otherCancel": "Avbryt",
 
-    "notificationsSent": "Skickades",
+    "notificationsSent": "Skickades ",
     "notificationsNone": "Inga notiser tillgängliga",
 
     "contactContact": "Kontakt",

--- a/lib/models/notiser/notis.dart
+++ b/lib/models/notiser/notis.dart
@@ -6,7 +6,7 @@ part 'notis.g.dart';
 class Notis {
   int? id; 
   DateTime? created_at; 
-  bool? seen; 
+  bool? seen; //Seems to be legacy field from backend. Use 'visited'
   bool? visited;
   Map<String, String?>? data;
   int? event_id;

--- a/lib/screens/notiser/notiser.dart
+++ b/lib/screens/notiser/notiser.dart
@@ -37,7 +37,7 @@ class _NotiserPageState extends State<NotiserPage> {
           if (notis.data == null) return Container();
 
           return Card(
-              color: notis.seen ?? false ? Colors.white : Colors.orange[200],
+              color: notis.visited ?? false ? Colors.white : Colors.orange[200],
               child: Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: InkWell(
@@ -79,7 +79,7 @@ class _NotiserPageState extends State<NotiserPage> {
   void seeNotis(Notis notis) {
     locator<NotiserService>().visitNotis(notis.id!);
     setState(() {
-      _pagingController.itemList!.singleWhere((element) => element.id == notis.id).seen = true;
+      _pagingController.itemList!.singleWhere((element) => element.id == notis.id).visited = true;
     });
     Navigator.push(context, MaterialPageRoute(builder: (context) => EventPage(eventId: notis.event_id!)));
   }


### PR DESCRIPTION
Resolves #94 

Can't test cuz Idunno how to send notifications. But pretty sure this solves it because:

To mark a notification as viewed, the route PATCH /anvandare/notifikationer/\<notificationId\>/visit are called by both web and app upon clicking on a notification.

Looking at the web, it used the `visited` field of the notification to mark as viewed or not.

App used `seen` which seems to be an old field as seen in app/controllers/api/notifications_controller.rb

<img width="559" alt="image" src="https://user-images.githubusercontent.com/77930606/195137680-db9c7945-d6ec-4e66-b9ee-60e20b4a7a2f.png">

