### PR TITLE
Hopefully locked screen rotation

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,8 +34,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fsek_mobile/content_wrapper.dart';
 import 'package:fsek_mobile/services/abstract.service.dart';
@@ -108,6 +109,7 @@ class _FsekMobileAppState extends State<FsekMobileApp> {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
     return BlocProvider<AuthenticationBloc>(
         create: (context) => _authenticationBloc!,
         child: MaterialApp(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/services.dart';
 import 'package:fsek_mobile/app.dart';
 import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
@@ -70,7 +69,11 @@ void main() async {
       backgroundColor: Colors.transparent,
     ),
     SizedBox(width: 16),
-    Text("F-sektionen", style: TextStyle(fontFamily: 'Helvetica Neue', fontSize: 28.0, color: Colors.grey[700]))
+    Text("F-sektionen",
+        style: TextStyle(
+            fontFamily: 'Helvetica Neue',
+            fontSize: 28.0,
+            color: Colors.grey[700]))
   ];
   // This captures errors reported by the Flutter framework.
   FlutterError.onError = (FlutterErrorDetails details) {
@@ -92,7 +95,6 @@ void main() async {
   FirebaseMessaging.onBackgroundMessage(_backgroundMessagingHandler);
 
   runZonedGuarded<void>(() {
-    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
     runApp(FsekMobileApp());
   }, (Object error, StackTrace stackTrace) {
     // Whenever an error occurs, call the `_reportError` function. This sends

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: Mobile application for the F-guild
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 
-version: 1.5.6122+1 #buildnumber incremented automatically in codemagic
+version: 1.6.6122+1 #buildnumber incremented automatically in codemagic
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Screen rotation lock seemed to have stopped working, similar to: https://stackoverflow.com/questions/49418332/flutter-how-to-prevent-device-orientation-changes-and-force-portrait. Changed accordingly, but we need to test on ios as well.