### PR TITLE
Target API version 33 and remove debug prints

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
     defaultConfig {
         applicationId "se.fsektionen.fapp"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
+            android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
@@ -39,7 +40,10 @@
             android:value="2" />
         <meta-data
           android:name="com.google.firebase.messaging.default_notification_channel_id"
-          android:value="high_importance_channel" />
+          android:value="high_importance_channel"/>
+        <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="true">   
+        </receiver>
     </application>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/lib/screens/guildmeeting/motions.dart
+++ b/lib/screens/guildmeeting/motions.dart
@@ -1,129 +1,24 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:fsek_mobile/models/documents/election_document.dart';
-import 'package:fsek_mobile/services/service_locator.dart';
-import 'package:fsek_mobile/services/document.service.dart';
-
-import 'motion_card.dart';
-
-class MotionsPage extends StatefulWidget {
-  @override
-  _MotionsPageState createState() => _MotionsPageState();
-}
-
-class _MotionsPageState extends State<MotionsPage> with TickerProviderStateMixin {
-  List<List<ElectionDocument?>>? documents = [];
-  List<List<ElectionDocument?>>? allDocuments = [];
-
-  //bad helpvariables that are most likely unneeded
-  bool searchFocus = false;
-  String initChar = "";
-
-  TextEditingController _controller = TextEditingController();
-
-  late AnimationController animationController;
-  late Animation<double> animation;
-
-  @override
-  void initState() {
-    locator<DocumentService>().getMotionsAndAnswers("Val").then((value) => setState(() {
-          if (!listEquals(value, [])) {
-            this.documents = value;
-            // 0th value is the motion, which should always exist if we get a non null response
-            documents!.sort((a, b) => a[0]!.document_name!.compareTo(b[0]!.document_name!));
-            allDocuments = List.from(documents!);
-          } else {
-            this.documents = null;
-            allDocuments = null;
-          }
-        }));
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  Widget build(BuildContext context) {
-    var t = AppLocalizations.of(context)!;
-    return listEquals(allDocuments, [])
-        ? Scaffold(appBar: AppBar(title: Text(t.motionsPageTitle)), body: Center(child: CircularProgressIndicator(color: Colors.orange[600])))
-        : GestureDetector(
-            onTap: () => FocusScope.of(context).unfocus(),
-            child: Scaffold(
-              appBar: AppBar(title: Text(t.motionsPageTitle)),
-              body: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  FocusScope(
-                      child: Focus(
-                    onFocusChange: (focus) {
-                      //print(focus);
-                      setState(() {
-                        searchFocus = focus;
-                      });
-                    },
-                    child: TextField(
-                      controller: _controller,
-                      decoration: InputDecoration(
-                          prefixIcon: searchFocus
-                              ? IconButton(
-                                  icon: Icon(
-                                    Icons.arrow_back,
-                                    color: Colors.grey[800],
-                                  ),
-                                  onPressed: () => FocusScope.of(context).unfocus())
-                              : Icon(
-                                  Icons.search,
-                                  color: Colors.grey[800],
-                                ),
-                          hintText: t.songbookSearch,
-                          suffixIcon: _controller.text.length > 0
-                              ? IconButton(
-                                  icon: Icon(Icons.clear),
-                                  color: Colors.grey[800],
-                                  onPressed: () => setState(() {
-                                        _controller.clear();
-                                        FocusScope.of(context).unfocus();
-                                        documents = allDocuments;
-                                      }))
-                              : SizedBox.shrink()),
-                      onChanged: (search) {
-                        print(search == "");
-                        print(search);
-                        List<String> searchTerms = search.toLowerCase().trim().split(new RegExp(r"\s+"));
-                        setState(() {
-                          initChar = "";
-                          if (documents != null) {
-                            documents = allDocuments!.where((document) {
-                              return searchTerms.every((term) => document[0]!.document_name!.toLowerCase().contains(term));
-                            }).toList();
-                          }
-                        });
-                      },
-                    ),
-                  )),
-                  Expanded(
-                    child: documents != null
-                        ? ListView(
-                            children: documents!.map((document) => _generateDocumentTile(document[0]!, document.length > 1 ? document[1] : null)).toList(),
-                          )
-                        : Padding(
-                            padding: EdgeInsets.all(16),
-                            child: Text(t.noMotions),
-                          ),
-                  )
-                ],
-              ),
-            ));
-  }
-
-  Widget _generateDocumentTile(ElectionDocument motion, ElectionDocument? motion_answer) {
-    return Column(children: [
-      MotionCard(motion: motion, motionResponse: motion_answer),
-    ]);
-  }
-}
+class _MotionsPageState extends State<MotionsPage>
+    with TickerProviderStateMixin {
+    locator<DocumentService>()
+        .getMotionsAndAnswers("Val")
+        .then((value) => setState(() {
+                documents!.sort((a, b) =>
+                    a[0]!.document_name!.compareTo(b[0]!.document_name!));
+                                  onPressed: () =>
+                                      FocusScope.of(context).unfocus())
+                        List<String> searchTerms = search
+                            .toLowerCase()
+                            .trim()
+                            .split(new RegExp(r"\s+"));
+                              return searchTerms.every((term) => document[0]!
+                                  .document_name!
+                                  .toLowerCase()
+                                  .contains(term));
+                            children: documents!
+                                .map((document) => _generateDocumentTile(
+                                    document[0]!,
+                                    document.length > 1 ? document[1] : null))
+                                .toList(),
+  Widget _generateDocumentTile(
+      ElectionDocument motion, ElectionDocument? motion_answer) {

--- a/lib/screens/songbook/songbook.dart
+++ b/lib/screens/songbook/songbook.dart
@@ -73,7 +73,6 @@ class _SongbookPageState extends State<SongbookPage>
                       FocusScope(
                           child: Focus(
                         onFocusChange: (focus) {
-                          print(focus);
                           setState(() {
                             searchFocus = focus;
                           });

--- a/lib/util/authentication/login_bloc.dart
+++ b/lib/util/authentication/login_bloc.dart
@@ -30,14 +30,15 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
           email: event.username,
           pass: event.password,
         );
-      }
-      catch(ex) {
-        authenticationBloc.add(AppError(error: ex.toString())); // Make sure we show an error that we cant connect
+      } catch (ex) {
+        authenticationBloc.add(AppError(
+            error: ex
+                .toString())); // Make sure we show an error that we cant connect
         yield LoginInitial();
-        return;   
+        return;
       }
-      
-      if(token.error != null && token.error.isNotEmpty) {
+
+      if (token.error != null && token.error.isNotEmpty) {
         yield LoginFailure(error: token.error);
         return;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -776,7 +776,7 @@ packages:
       name: permission_handler_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.7"
+    version: "9.0.8"
   permission_handler_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
Tested this on emulators with android 11, 12 and 13, which target API versions 30, 31 and 33 respectively. I think we might as well target 33 since it will be mandatory from august, and we need to target at least 31 currently.  Someone should probably try this on a physical device (or we could just send it and pray). As for the min version, it might be a good idea to set that to 30 since I'm not sure how far down we actually go given the new dependencies, and that is in the range of what we actually test.