### PR TITLE
Fixfixfix

### DIFF
--- a/lib/screens/moose_game/ground.dart
+++ b/lib/screens/moose_game/ground.dart
@@ -14,7 +14,6 @@ class Ground extends GameObject {
 
   Ground(double xPosition, double floorY) : super(Vector2(xPosition, floorY)) {
     sprite = groundSprite;
-    print(sprite.imagePath);
   }
 
   @override

--- a/lib/screens/moose_game/highscore.dart
+++ b/lib/screens/moose_game/highscore.dart
@@ -47,9 +47,9 @@ class _HighscorePageState extends State<HighscorePage>
         
       String? enteredName = "";
       
-      while(enteredName.isEmpty) {
+      while(enteredName!.isEmpty) {
 
-        String? enteredName = await inputDialog(context,
+        enteredName = await inputDialog(context,
             "Enter a nickname (can be changed in settings)", "Name", true);
 
         // If cancelled then go back

--- a/lib/screens/moose_game/highscore.dart
+++ b/lib/screens/moose_game/highscore.dart
@@ -54,7 +54,11 @@ class _HighscorePageState extends State<HighscorePage>
 
         // If cancelled then go back
         if (enteredName == null) return;
-        if(enteredName.isEmpty) continue;
+        if (enteredName.isEmpty) continue;
+
+        // I hate this btw
+        // This is a empty char added for version control
+        enteredName = enteredName + "\u{200E}";
 
         user!.game_nickname = enteredName;
         

--- a/lib/screens/moose_game/moose_game.dart
+++ b/lib/screens/moose_game/moose_game.dart
@@ -38,7 +38,7 @@ const startGameSpeed = 4;
 const maxGameSpeed = 11;
 const secondsToReachMaxApprox = 60;
 
-class _MooseGamePageState extends State<MooseGamePage> with SingleTickerProviderStateMixin {
+class _MooseGamePageState extends State<MooseGamePage> with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   final String idleLink = "assets/img/moose_game/hilbert_scaled_idle.png";
   final String duckingLink = "assets/img/moose_game/hilbert_scaled_ducking.png";
   final Color googleDinosaurColor = Color.fromRGBO(83, 83, 83, 1.0);
@@ -61,10 +61,22 @@ class _MooseGamePageState extends State<MooseGamePage> with SingleTickerProvider
 
   bool isDead = false;
 
+  // This keeps track of if the app is in the foreground or background
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) {
+      setState(() {
+        gameOver();
+      });
+    }
+  }
+
   @override
   void initState() {
     super.initState();
 
+    WidgetsBinding.instance.addObserver(this);
+    
     cameraPos = Vector2.zero();
     late int tempuserid; 
     locator<UserService>().getUser().then((user) => tempuserid = user.id ?? 0);
@@ -86,6 +98,8 @@ class _MooseGamePageState extends State<MooseGamePage> with SingleTickerProvider
   void dispose() {
     gameAnimController.stop();
     gameAnimController.dispose();
+
+    WidgetsBinding.instance.removeObserver(this);
 
     super.dispose();
   }

--- a/lib/screens/moose_game/obstacle.dart
+++ b/lib/screens/moose_game/obstacle.dart
@@ -18,7 +18,6 @@ class Obstacle extends GameObject {
 
   Obstacle(double xPosition, double floorY) : super(Vector2(xPosition, floorY)) {
     sprite = possibleSprites[Random().nextInt(possibleSprites.length)];
-    print(sprite.imagePath);
   }
 
   @override

--- a/lib/screens/other/fap.dart
+++ b/lib/screens/other/fap.dart
@@ -32,8 +32,8 @@ class _FapPageState extends State<FapPage> {
       "Oskar Watsfeldt, ${t.fapSpider} 2022",
       "Louise Drenth, ${t.fapSuper} 2023",
       "Emma Engdahl, ${t.fapSpider} 2023",
-      "Hjalmar Mårtensson ${t.fapSpider} 2023",
-      "Samuel Trobbiani ${t.fapSuper} 2024",
+      "Hjalmar Mårtensson, ${t.fapSpider} 2023",
+      "Samuel Trobbiani, ${t.fapSuper} 2024",
       "Georg Elgebäck, ${t.fapSpider} 2024",
       "Moa Söderström, ${t.fapSpider} 2024",
     ];

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -90,11 +90,13 @@ class _SettingsPageState extends State<SettingsPage> {
                   user!.firstname,
                   (input) => user!.firstname = input,
                 ),
-                _makeTextField( "Game nickname", user!.game_nickname,
+                _makeTextField( "Game nickname", user!.game_nickname?.replaceAll("\u{200E}", ""),
                   // TODO use translate var
                   (input) {
                     changedSetting = true;
-                    user!.game_nickname = input;
+                    if (input == null) user!.game_nickname = input;
+                    // remove version control char if it exists, then add it back at the end
+                    else user!.game_nickname = input.replaceAll("\u{200E}", "") + "\u{200E}";
                   },
                 ),
                 _makeDropDown<String>(

--- a/lib/services/game.service.dart
+++ b/lib/services/game.service.dart
@@ -2,21 +2,46 @@ import 'package:fsek_mobile/services/abstract.service.dart';
 import 'package:fsek_mobile/models/moose_game/game_score_entry.dart';
 import 'package:fsek_mobile/services/service_locator.dart';
 import 'package:fsek_mobile/services/user.service.dart';
+import 'package:fsek_mobile/models/user/user.dart';
 
 class GameScoreService extends AbstractService {
+  User? user;
+
   Future<List<GameScoreEntry>> getScores() async {
     Map json = await AbstractService.get("/game_scores");
 
     List<GameScoreEntry> result = (json['game_scores'] as List)
         .map((data) => GameScoreEntry.fromJson(data))
         .toList();
+
+    // remove all users which use their real name
+    // If this isn't done I would have to mess with real names
+    // to get version control and stop bad actors
+    result.removeWhere((element) => element.user!.game_nickname == null);
+
+    // remove all names without a blank char in them to stop bad actors on old versions
+    // All users who update their names on the new version will have a blank char in them
+    // therefore (pretty much) only users on old versions will be removed
+    result.removeWhere((element) => !element.user!.game_nickname!.contains("\u{200E}"));
     return result;
   }
   Future<Map> postScore({ score = int }) async {
-
     return AbstractService.post("/game_scores", mapBody: { 
       "score": score,
       "user": await locator<UserService>().getUser()
     });
+  }
+  Future<Map> resetScore() async {
+    return AbstractService.post("/game_scores", mapBody: { 
+      "score": 0,
+      "user": await locator<UserService>().getUser()
+    });
+  }
+  Future<Map> resetName() async {
+    user = await locator<UserService>().getUser();
+
+    user!.game_nickname = null;
+
+    return await locator<UserService>().updateUser(user!);
   }
 }

--- a/lib/widgets/bottom_app_bar.dart
+++ b/lib/widgets/bottom_app_bar.dart
@@ -5,6 +5,8 @@ import 'package:fsek_mobile/screens/moose_game/moose_game.dart';
 import 'package:fsek_mobile/widgets/easterEgg/animated_nils.dart';
 import 'package:fsek_mobile/widgets/easterEgg/easteregg_code_dialog.dart';
 import 'package:fsek_mobile/widgets/easterEgg/familyGuyFoset.dart';
+import 'package:fsek_mobile/services/service_locator.dart';
+import 'package:fsek_mobile/services/game.service.dart';
 
 class FsekAppBarItem {
   FsekAppBarItem({this.iconData, this.text});
@@ -97,6 +99,14 @@ class FsekAppBarState extends State<FsekAppBar> {
 
       case "moosegame":
         Navigator.push(context, MaterialPageRoute(builder: (context) => (MooseGamePage())));
+        break;
+
+      case "reset moose":
+        locator<GameScoreService>().resetScore();
+        break;
+
+      case "reset name":
+        locator<GameScoreService>().resetName();
         break;
 
       default:


### PR DESCRIPTION
Version control that is kinda cursed (should probably be removed in a release or two) to prevent players on old versions from exploiting a bug. The high score page no longer asks for the name to be inputted constantly and you can now reset your own moose game score and game name with "reset score" / "reset name" in secret code menu.