### PR TITLE
Fixed a presumed moose game score exploit

### DIFF
--- a/lib/screens/moose_game/highscore.dart
+++ b/lib/screens/moose_game/highscore.dart
@@ -41,7 +41,7 @@ class _HighscorePageState extends State<HighscorePage>
         }));
     locator<UserService>().getUser().then((value) async {
       user = value;
-      //Set users nickname if first time playing game
+      // Set users nickname if first time playing game
       // TODO add translate var
       if (user!.game_nickname != null) return;
         
@@ -57,8 +57,8 @@ class _HighscorePageState extends State<HighscorePage>
         if (enteredName.isEmpty) continue;
 
         // I hate this btw
-        // This is a empty char added for version control
-        enteredName = enteredName + "\u{200E}";
+        // This is a empty char added for version control, but first the name is cleaned up
+        enteredName = enteredName.replaceAll("\u{200E}", "") + "\u{200E}";
 
         user!.game_nickname = enteredName;
         

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:fsek_mobile/models/user/user.dart';
 import 'package:fsek_mobile/services/service_locator.dart';
 import 'package:fsek_mobile/services/user.service.dart';
+import 'package:fsek_mobile/services/game.service.dart';
 import 'package:intl/intl.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -93,6 +94,17 @@ class _SettingsPageState extends State<SettingsPage> {
                 _makeTextField( "Game nickname", user!.game_nickname?.replaceAll("\u{200E}", ""),
                   // TODO use translate var
                   (input) {
+
+                    // Version control check
+                    if (user!.game_nickname != null) {
+                      if (!user!.game_nickname!.contains("\u{200E}"))
+                      {
+                        // The user has not updated their nickname since the version control was added
+                        // this means they might have a cheated in score
+                        locator<GameScoreService>().resetScore();
+                      }
+                    }
+                    
                     changedSetting = true;
                     if (input == null) user!.game_nickname = input;
                     // remove version control char if it exists, then add it back at the end

--- a/lib/widgets/bottom_app_bar.dart
+++ b/lib/widgets/bottom_app_bar.dart
@@ -101,7 +101,7 @@ class FsekAppBarState extends State<FsekAppBar> {
         Navigator.push(context, MaterialPageRoute(builder: (context) => (MooseGamePage())));
         break;
 
-      case "reset moose":
+      case "reset score":
         locator<GameScoreService>().resetScore();
         break;
 


### PR DESCRIPTION
If someone gets a cheated score in moose game and then updated to the new version they could keep the old cheated score. This fixes that (and changes some words and comments).